### PR TITLE
Fix createFiles function to handle cases where activity programming language is nil

### DIFF
--- a/lua/dodona/manager.lua
+++ b/lua/dodona/manager.lua
@@ -33,25 +33,24 @@ function M.subscribedCourses()
 end
 
 function M.createFiles(activities)
-	local dir = vim.fn.expand("%:p:h")
-	for key, activity in ipairs(activities) do
-        
+    local dir = vim.fn.expand("%:p:h")
+
+    for key, activity in ipairs(activities) do
         if activity.programming_language ~= nil then
             local filename = key .. "_" .. activity.name .. "." .. activity.programming_language.extension
-            local file = io.open(dir .. "/" .. filename:gsub(" ", "_"), "a")
+            local file = io.open(dir .. "/" .. filename:gsub(" ", "_"), "a") 
+
+            if file ~= nil then
+                local c = comments[activity.programming_language.name]
+                file:write((c ~= nil and c or "") .. string.sub(activity.url, 1, -6) .. "/\n")
+                if activity.boilerplate ~= vim.NIL then
+                    file:write('\n' .. activity.boilerplate)
+                end
+                file:close()
+                notify(dir .. "/" .. filename:gsub(" ", "_") .. " file created", "info")
+            end
         end
-
-    if file ~= nil then
-      local c = comments[activity.programming_language.name]
-      file:write((c ~= nil and c or "") .. string.sub(activity.url, 1, -6) .. "/\n")
-      if activity.boilerplate ~= vim.NIL then
-        file:write('\n' .. activity.boilerplate)
-      end
-      file:close()
-
-      notify(dir .. "/" .. filename:gsub(" ","_") .. " file created", "info")
     end
-	end
 end
 
 local function check_evaluated(url)

--- a/lua/dodona/manager.lua
+++ b/lua/dodona/manager.lua
@@ -35,8 +35,11 @@ end
 function M.createFiles(activities)
 	local dir = vim.fn.expand("%:p:h")
 	for key, activity in ipairs(activities) do
-		local filename = key .. "_" .. activity.name .. "." .. activity.programming_language.extension
-		local file = io.open(dir .. "/" .. filename:gsub(" ", "_"), "a")
+        
+        if activity.programming_language ~= nil then
+            local filename = key .. "_" .. activity.name .. "." .. activity.programming_language.extension
+            local file = io.open(dir .. "/" .. filename:gsub(" ", "_"), "a")
+        end
 
     if file ~= nil then
       local c = comments[activity.programming_language.name]


### PR DESCRIPTION
This pull request addresses an issue in the createFiles function where it fails to handle cases where the programming language of an activity `activity.programming_language` is nil. By adding a conditional check to ensure that the programming language is not nil before attempting to create a file, this fix ensures the function behaves correctly and prevents potential errors.
